### PR TITLE
Copy over initial implementation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
---require spec_helper
+--order random

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     graphql-page_cursors (0.0.1)
+      graphql
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
     diff-lcs (1.4.4)
+    graphql (1.11.6)
     parallel (1.20.0)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/graphql-page_cursors.gemspec
+++ b/graphql-page_cursors.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'graphql'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/graphql-page_cursors.gemspec
+++ b/graphql-page_cursors.gemspec
@@ -6,7 +6,7 @@ require 'graphql/page_cursors/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'graphql-page_cursors'
-  spec.version       = Graphql::PageCursors::VERSION
+  spec.version       = GraphQL::PageCursors::VERSION
   spec.authors       = ['Jon Allured']
   spec.email         = ['jon.allured@gmail.com']
 

--- a/lib/graphql/page_cursors.rb
+++ b/lib/graphql/page_cursors.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'graphql'
+
 require 'graphql/page_cursors/version'
 
-module Graphql
+module GraphQL
   module PageCursors
     # Your code goes here...
   end

--- a/lib/graphql/page_cursors.rb
+++ b/lib/graphql/page_cursors.rb
@@ -5,7 +5,134 @@ require 'graphql'
 require 'graphql/page_cursors/version'
 
 module GraphQL
-  module PageCursors
-    # Your code goes here...
+  class PageCursor < GraphQL::Schema::Object
+    field :cursor, String, 'first cursor on the page', null: false
+    field :isCurrent, Boolean, 'is this the current page?', null: false
+    field :page, Int, 'page number out of totalPages', null: false
+  end
+
+  class PageCursors < GraphQL::Schema::Object
+    field :first, PageCursor, 'optional, may be included in field around', null: true
+    field :last, PageCursor, 'optional, may be included in field around', null: true
+    field :around, [PageCursor], null: false
+    field :previous, PageCursor, null: true
+  end
+
+  class PageCursorConnection < GraphQL::Types::Relay::BaseConnection
+    field :page_cursors, PageCursors, null: true
+    field :total_pages, Int, null: true
+    field :total_count, Int, null: true
+
+    MAX_CURSOR_COUNT = 5
+
+    def page_cursors
+      return if total_pages <= 1
+
+      {
+        around: around_cursors,
+        first: first_cursor,
+        last: last_cursor,
+        previous: previous_cursor
+      }.compact
+    end
+
+    def total_pages
+      return 0 if object.items.size.zero?
+      return 1 if nodes_per_page.nil?
+
+      (object.items.size.to_f / nodes_per_page).ceil
+    end
+
+    def total_count
+      object.items.size
+    end
+
+    private
+
+    def around_cursors
+      around_page_numbers.map { |page_num| page_cursor(page_num) }
+    end
+
+    def first_cursor
+      exceeds_max_cursor_count = total_pages > MAX_CURSOR_COUNT
+      include_first_cursor =
+        exceeds_max_cursor_count && around_page_numbers.exclude?(1)
+      return unless include_first_cursor
+
+      page_cursor(1)
+    end
+
+    def last_cursor
+      exceeds_max_cursor_count = total_pages > MAX_CURSOR_COUNT
+      include_last_cursor =
+        exceeds_max_cursor_count && around_page_numbers.exclude?(total_pages)
+      return unless include_last_cursor
+
+      page_cursor(total_pages)
+    end
+
+    def previous_cursor
+      include_previous_cursor = current_page > 1
+      return unless include_previous_cursor
+
+      page_cursor(current_page - 1)
+    end
+
+    def page_cursor(page_num)
+      {
+        cursor: cursor_for_page(page_num),
+        is_current: current_page == page_num,
+        page: page_num
+      }
+    end
+
+    def cursor_for_page(page_num)
+      return '' if page_num == 1
+
+      after_cursor = (page_num - 1) * nodes_per_page
+      encode(after_cursor.to_s)
+    end
+
+    def current_page
+      nodes_before / nodes_per_page + 1
+    end
+
+    def around_page_numbers # rubocop:disable Metrics/AbcSize
+      if total_pages <= MAX_CURSOR_COUNT
+        (1..total_pages).to_a
+      elsif current_page <= 3
+        (1..4).to_a
+      elsif current_page >= total_pages - 2
+        ((total_pages - 3)..total_pages).to_a
+      else
+        [current_page - 1, current_page, current_page + 1]
+      end
+    end
+
+    def nodes_before
+      node_offset(object.edge_nodes.first) - 1
+    end
+
+    def nodes_after
+      node_offset(object.edge_nodes.last)
+    end
+
+    def node_offset(node)
+      # this was previously accomplished by calling a private method:
+      # object.send(:offset_from_cursor, object.cursor_from_node(object.edge_nodes.first))
+      object.items.index(node) + 1
+    end
+
+    def nodes_per_page
+      object.first || object.last
+    end
+
+    # borrowed from https://graphql-ruby.org/api-doc/1.10.6/Base64Bp.html
+    def encode(value)
+      str = Base64.strict_encode64(value)
+      str.tr!('+/', '-_')
+      str.delete!('=')
+      str
+    end
   end
 end

--- a/lib/graphql/page_cursors/version.rb
+++ b/lib/graphql/page_cursors/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Graphql
+module GraphQL
   module PageCursors
     VERSION = '0.0.1'
   end

--- a/spec/graphql/page_cursors_spec.rb
+++ b/spec/graphql/page_cursors_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Graphql::PageCursors do
+RSpec.describe GraphQL::PageCursors do
   it 'has a version number' do
-    expect(Graphql::PageCursors::VERSION).not_to be nil
+    expect(GraphQL::PageCursors::VERSION).not_to be nil
   end
 end


### PR DESCRIPTION
This PR copies over the implementation we've been duplicating across Artsy projects. I did a little renaming:

Before | After | Superclass
-------|-------|---------- 
`Types::Pagination::PageableConnection` | `GraphQL::PageCursorConnection` | `GraphQL::Types::Relay::BaseConnection`
`Types::Pagination::PageCursorsType` | `GraphQL::PageCursors` | `GraphQL::Schema::Object`
`Types::Pagination::PageCursorType` | `GraphQL::PageCursor` | `GraphQL::Schema::Object`

I might regret this, but here was my thought process:

* The `Types` namespace is really for applications to subclass the classes provided by the `graphql` gem.
* The `Pagination` namespace is an extra level of grouping that's not used.
* Adding the `Type` suffix seems unnecessary.
* Tucking these three classes directly under the `GraphQL` module is bold, but calls out that these classes are different.

In the end, this probably doesn't matter, but is one of those things where one has to make a call and move on. Future Jon can always move things if we need him to!

At this point, I believe it would technically be possible to pull in this gem and replace the duplicated code by using the table above to find/replace constant names. So that's my next step - pull this gem into Robot Doc and see if I can get it to work correctly.