### PR TITLE
fix: Update name of field

### DIFF
--- a/graphql-page_cursors.gemspec
+++ b/graphql-page_cursors.gemspec
@@ -2,11 +2,11 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'graphql/page_cursors/version'
+require 'page_cursors/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'graphql-page_cursors'
-  spec.version       = GraphQL::PageCursors::VERSION
+  spec.version       = PageCursors::VERSION
   spec.authors       = ['Jon Allured']
   spec.email         = ['jon.allured@gmail.com']
 

--- a/lib/graphql/page_cursors.rb
+++ b/lib/graphql/page_cursors.rb
@@ -2,8 +2,6 @@
 
 require 'graphql'
 
-require 'graphql/page_cursors/version'
-
 module GraphQL
   class PageCursor < GraphQL::Schema::Object
     field :cursor, String, 'first cursor on the page', null: false

--- a/lib/graphql/page_cursors.rb
+++ b/lib/graphql/page_cursors.rb
@@ -7,7 +7,7 @@ require 'graphql/page_cursors/version'
 module GraphQL
   class PageCursor < GraphQL::Schema::Object
     field :cursor, String, 'first cursor on the page', null: false
-    field :isCurrent, Boolean, 'is this the current page?', null: false
+    field :is_current, Boolean, 'is this the current page?', null: false
     field :page, Int, 'page number out of totalPages', null: false
   end
 

--- a/lib/graphql/page_cursors/version.rb
+++ b/lib/graphql/page_cursors/version.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module GraphQL
-  module PageCursors
-    VERSION = '0.0.1'
-  end
-end

--- a/lib/page_cursors/version.rb
+++ b/lib/page_cursors/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PageCursors
+  VERSION = '0.0.1'
+end

--- a/spec/graphql/page_cursors_spec.rb
+++ b/spec/graphql/page_cursors_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe GraphQL::PageCursors do
+RSpec.describe PageCursors do
   it 'has a version number' do
-    expect(GraphQL::PageCursors::VERSION).not_to be nil
+    expect(PageCursors::VERSION).not_to be nil
   end
 end


### PR DESCRIPTION
This PR fixes a typo on `isCurrent` that was causing us grief and then we also moved some things around to have better organization.