### PR TITLE
fix: Update gem spec

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,16 @@
+#! /bin/sh
+set -ex
+
+old_version=$1
+new_version=$2
+
+version_files="lib/page_cursors/version.rb"
+commit_message="Bumping version numbers for $new_version"
+tag_message="Tagging version $new_version"
+
+sed -i "" "s/$old_version/$new_version/g" $version_files
+git add .
+git commit --message "$commit_message"
+git push upstream main
+git tag --annotate v$new_version --message "$tag_message"
+git push upstream --tags

--- a/graphql-page_cursors.gemspec
+++ b/graphql-page_cursors.gemspec
@@ -15,17 +15,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/artsy/graphql-page_cursors'
   spec.license       = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end


### PR DESCRIPTION
I hadn't really looked through the generated spec file from Bundler and it turns out there was a bit of unnecessary setup in there. I also have added a release script that I copy/pasted a bit from another project.