### PR TITLE
feat: Extract class for page cursor

### DIFF
--- a/lib/page_cursor.rb
+++ b/lib/page_cursor.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+class PageCursor
+  def self.as_hash(current_page, page_number, per_page)
+    new(current_page, page_number, per_page).to_hash
+  end
+
+  attr_reader :current_page, :page_number, :per_page
+
+  def initialize(current_page, page_number, per_page)
+    @current_page = current_page
+    @page_number = page_number
+    @per_page = per_page
+  end
+
+  def to_hash
+    {
+      cursor: encoded_cursor,
+      is_current: current?,
+      page: page_number
+    }
+  end
+
+  private
+
+  def current?
+    current_page == page_number
+  end
+
+  def encoded_cursor
+    previous_page = page_number - 1
+    return '' if previous_page.zero?
+
+    after_cursor = previous_page * per_page
+    encoded = Base64.strict_encode64(after_cursor.to_s)
+    encoded.tr('+/', '-_').delete('=')
+  end
+end

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'base64'
+require 'page_cursor'
 
 class PageCursorResolver
   MAX_CURSOR_COUNT = 5
@@ -65,19 +65,8 @@ class PageCursorResolver
     page_cursor(current_page - 1)
   end
 
-  def page_cursor(page_num)
-    {
-      cursor: cursor_for_page(page_num),
-      is_current: current_page == page_num,
-      page: page_num
-    }
-  end
-
-  def cursor_for_page(page_num)
-    return '' if page_num == 1
-
-    after_cursor = (page_num - 1) * nodes_per_page
-    encode(after_cursor.to_s)
+  def page_cursor(page_number)
+    PageCursor.as_hash(current_page, page_number, nodes_per_page)
   end
 
   def current_page
@@ -112,13 +101,5 @@ class PageCursorResolver
 
   def nodes_per_page
     object.first || object.last
-  end
-
-  # borrowed from https://graphql-ruby.org/api-doc/1.10.6/Base64Bp.html
-  def encode(value)
-    str = Base64.strict_encode64(value)
-    str.tr!('+/', '-_')
-    str.delete!('=')
-    str
   end
 end


### PR DESCRIPTION
This PR extracts a PageCursor object that can be used to encapsulate the logic and behavior around the individual cursors returned in the larger page_cursors field. It ends up moving the base64 encoding too so that's now at a lower part of the stack.