### PR TITLE
Refactor resolver

### DIFF
--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -75,10 +75,6 @@ class PageCursorResolver
     PageCursor.as_hash(current_page, page_number, nodes_per_page)
   end
 
-  def current_page
-    nodes_before / nodes_per_page + 1
-  end
-
   def around_page_numbers # rubocop:disable Metrics/AbcSize
     if total_pages <= MAX_CURSOR_COUNT
       (1..total_pages).to_a
@@ -91,14 +87,11 @@ class PageCursorResolver
     end
   end
 
-  def nodes_before
-    node_offset(object.edge_nodes.first) - 1
-  end
-
-  def node_offset(node)
-    # this was previously accomplished by calling a private method:
-    # object.send(:offset_from_cursor, object.cursor_from_node(object.edge_nodes.first))
-    object_items.index(node) + 1
+  def current_page
+    first_node = object.edge_nodes.first
+    item_index = object_items.index(first_node) || 0
+    nodes_before = item_index + 1
+    nodes_before / nodes_per_page + 1
   end
 
   def nodes_per_page

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -95,10 +95,6 @@ class PageCursorResolver
     node_offset(object.edge_nodes.first) - 1
   end
 
-  def nodes_after
-    node_offset(object.edge_nodes.last)
-  end
-
   def node_offset(node)
     # this was previously accomplished by calling a private method:
     # object.send(:offset_from_cursor, object.cursor_from_node(object.edge_nodes.first))


### PR DESCRIPTION
This is a little refactor after realizing we had a complex dance going on when we didn't need it. The `nodes_after` method was not being called. The that lead me to see that the `nodes_before` and `node_offset` were just being used to compute `current_page`. So I removed the unused and in-lined the others and now things are more simple and I feel cleaner already!!