### PR TITLE
feat: Elevate types of pagination to classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-page_cursors (0.0.1)
+    graphql-page_cursors (0.0.2)
       graphql
 
 GEM

--- a/lib/base_page_cursors.rb
+++ b/lib/base_page_cursors.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class BasePageCursors
+  def self.as_hash(total_pages, current_page, per_page)
+    new(total_pages, current_page, per_page).to_hash
+  end
+
+  attr_reader :total_pages, :current_page, :per_page
+
+  def initialize(total_pages, current_page, per_page)
+    @total_pages = total_pages
+    @current_page = current_page
+    @per_page = per_page
+  end
+
+  def to_hash
+    {
+      around: around_cursors,
+      first: first_cursor,
+      last: last_cursor,
+      previous: previous_cursor
+    }.compact
+  end
+
+  private
+
+  def around_cursors
+    around_page_numbers.map { |page_number| cursor_for(page_number) }
+  end
+
+  def around_page_numbers
+    raise 'Implement in subclass'
+  end
+
+  def first_cursor
+    raise 'Implement in subclass'
+  end
+
+  def last_cursor
+    raise 'Implement in subclass'
+  end
+
+  def previous_cursor
+    raise 'Implement in subclass'
+  end
+
+  def cursor_for(page_number)
+    PageCursor.as_hash(current_page, page_number, per_page)
+  end
+end

--- a/lib/basic_page_cursors.rb
+++ b/lib/basic_page_cursors.rb
@@ -1,43 +1,21 @@
 # frozen_string_literal: true
 
-class BasicPageCursors
-  def self.as_hash(total_pages, current_page, per_page)
-    new(total_pages, current_page, per_page).to_hash
-  end
+require 'base_page_cursors'
 
-  attr_reader :total_pages, :current_page, :per_page
-
-  def initialize(total_pages, current_page, per_page)
-    @total_pages = total_pages
-    @current_page = current_page
-    @per_page = per_page
-  end
-
-  def to_hash
-    {
-      around: around_cursors,
-      previous: previous_cursor
-    }.compact
-  end
-
+class BasicPageCursors < BasePageCursors
   private
-
-  def around_cursors
-    around_page_numbers.map { |page_num| page_cursor(page_num) }
-  end
-
-  def previous_cursor
-    include_previous_cursor = current_page > 1
-    return unless include_previous_cursor
-
-    page_cursor(current_page - 1)
-  end
-
-  def page_cursor(page_number)
-    PageCursor.as_hash(current_page, page_number, per_page)
-  end
 
   def around_page_numbers
     (1..total_pages).to_a
+  end
+
+  def first_cursor; end
+
+  def last_cursor; end
+
+  def previous_cursor
+    return unless current_page > 1
+
+    cursor_for(current_page - 1)
   end
 end

--- a/lib/basic_page_cursors.rb
+++ b/lib/basic_page_cursors.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class BasicPageCursors
+  def self.as_hash(total_pages, current_page, per_page)
+    new(total_pages, current_page, per_page).to_hash
+  end
+
+  attr_reader :total_pages, :current_page, :per_page
+
+  def initialize(total_pages, current_page, per_page)
+    @total_pages = total_pages
+    @current_page = current_page
+    @per_page = per_page
+  end
+
+  def to_hash
+    {
+      around: around_cursors,
+      previous: previous_cursor
+    }
+  end
+
+  private
+
+  def around_cursors
+    around_page_numbers.map { |page_num| page_cursor(page_num) }
+  end
+
+  def previous_cursor
+    include_previous_cursor = current_page > 1
+    return unless include_previous_cursor
+
+    page_cursor(current_page - 1)
+  end
+
+  def page_cursor(page_number)
+    PageCursor.as_hash(current_page, page_number, per_page)
+  end
+
+  def around_page_numbers
+    (1..total_pages).to_a
+  end
+end

--- a/lib/gapped_page_cursors.rb
+++ b/lib/gapped_page_cursors.rb
@@ -1,57 +1,9 @@
 # frozen_string_literal: true
 
-class GappedPageCursors
-  def self.as_hash(total_pages, current_page, per_page)
-    new(total_pages, current_page, per_page).to_hash
-  end
+require 'base_page_cursors'
 
-  attr_reader :total_pages, :current_page, :per_page
-
-  def initialize(total_pages, current_page, per_page)
-    @total_pages = total_pages
-    @current_page = current_page
-    @per_page = per_page
-  end
-
-  def to_hash
-    {
-      around: around_cursors,
-      first: first_cursor,
-      last: last_cursor,
-      previous: previous_cursor
-    }.compact
-  end
-
+class GappedPageCursors < BasePageCursors
   private
-
-  def around_cursors
-    around_page_numbers.map { |page_num| page_cursor(page_num) }
-  end
-
-  def first_cursor
-    include_first_cursor = !around_page_numbers.include?(1)
-    return unless include_first_cursor
-
-    page_cursor(1)
-  end
-
-  def last_cursor
-    include_last_cursor = !around_page_numbers.include?(total_pages)
-    return unless include_last_cursor
-
-    page_cursor(total_pages)
-  end
-
-  def previous_cursor
-    include_previous_cursor = current_page > 1
-    return unless include_previous_cursor
-
-    page_cursor(current_page - 1)
-  end
-
-  def page_cursor(page_number)
-    PageCursor.as_hash(current_page, page_number, per_page)
-  end
 
   def around_page_numbers
     if current_page <= 3
@@ -61,5 +13,23 @@ class GappedPageCursors
     else
       [current_page - 1, current_page, current_page + 1]
     end
+  end
+
+  def first_cursor
+    return if around_page_numbers.include?(1)
+
+    cursor_for(1)
+  end
+
+  def last_cursor
+    return if around_page_numbers.include?(total_pages)
+
+    cursor_for(total_pages)
+  end
+
+  def previous_cursor
+    return unless current_page > 1
+
+    cursor_for(current_page - 1)
   end
 end

--- a/lib/gapped_page_cursors.rb
+++ b/lib/gapped_page_cursors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BasicPageCursors
+class GappedPageCursors
   def self.as_hash(total_pages, current_page, per_page)
     new(total_pages, current_page, per_page).to_hash
   end
@@ -16,6 +16,8 @@ class BasicPageCursors
   def to_hash
     {
       around: around_cursors,
+      first: first_cursor,
+      last: last_cursor,
       previous: previous_cursor
     }.compact
   end
@@ -24,6 +26,20 @@ class BasicPageCursors
 
   def around_cursors
     around_page_numbers.map { |page_num| page_cursor(page_num) }
+  end
+
+  def first_cursor
+    include_first_cursor = !around_page_numbers.include?(1)
+    return unless include_first_cursor
+
+    page_cursor(1)
+  end
+
+  def last_cursor
+    include_last_cursor = !around_page_numbers.include?(total_pages)
+    return unless include_last_cursor
+
+    page_cursor(total_pages)
   end
 
   def previous_cursor
@@ -38,6 +54,12 @@ class BasicPageCursors
   end
 
   def around_page_numbers
-    (1..total_pages).to_a
+    if current_page <= 3
+      (1..4).to_a
+    elsif current_page >= total_pages - 2
+      ((total_pages - 3)..total_pages).to_a
+    else
+      [current_page - 1, current_page, current_page + 1]
+    end
   end
 end

--- a/lib/null_page_cursors.rb
+++ b/lib/null_page_cursors.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class NullPageCursors
+  def self.as_hash(*_); end
+end

--- a/lib/null_page_cursors.rb
+++ b/lib/null_page_cursors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-class NullPageCursors
-  def self.as_hash(*_); end
+require 'base_page_cursors'
+
+class NullPageCursors < BasePageCursors
+  def to_hash; end
 end

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -6,6 +6,7 @@ require 'gapped_page_cursors'
 require 'null_page_cursors'
 
 class PageCursorResolver
+  MIN_CURSOR_COUNT = 2
   MAX_CURSOR_COUNT = 5
 
   attr_reader :object, :context
@@ -16,13 +17,7 @@ class PageCursorResolver
   end
 
   def page_cursors
-    if total_pages <= 1
-      NullPageCursors.as_hash(total_pages, current_page, per_page)
-    elsif total_pages <= MAX_CURSOR_COUNT
-      BasicPageCursors.as_hash(total_pages, current_page, per_page)
-    else
-      GappedPageCursors.as_hash(total_pages, current_page, per_page)
-    end
+    cursor_klass.as_hash(total_pages, current_page, per_page)
   end
 
   def total_pages
@@ -41,6 +36,16 @@ class PageCursorResolver
     return object.nodes unless object.respond_to?(:items)
 
     object.items
+  end
+
+  def cursor_klass
+    if total_pages < MIN_CURSOR_COUNT
+      NullPageCursors
+    elsif total_pages <= MAX_CURSOR_COUNT
+      BasicPageCursors
+    else
+      GappedPageCursors
+    end
   end
 
   def current_page

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -3,6 +3,7 @@
 require 'page_cursor'
 require 'basic_page_cursors'
 require 'gapped_page_cursors'
+require 'null_page_cursors'
 
 class PageCursorResolver
   MAX_CURSOR_COUNT = 5
@@ -15,9 +16,9 @@ class PageCursorResolver
   end
 
   def page_cursors
-    return if total_pages <= 1
-
-    if total_pages <= MAX_CURSOR_COUNT
+    if total_pages <= 1
+      NullPageCursors.as_hash(total_pages, current_page, per_page)
+    elsif total_pages <= MAX_CURSOR_COUNT
       BasicPageCursors.as_hash(total_pages, current_page, per_page)
     else
       GappedPageCursors.as_hash(total_pages, current_page, per_page)

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'page_cursor'
+require 'basic_page_cursors'
 
 class PageCursorResolver
   MAX_CURSOR_COUNT = 5
@@ -12,15 +13,19 @@ class PageCursorResolver
     @context = context
   end
 
-  def page_cursors
+  def page_cursors # rubocop:disable Metrics/MethodLength
     return if total_pages <= 1
 
-    {
-      around: around_cursors,
-      first: first_cursor,
-      last: last_cursor,
-      previous: previous_cursor
-    }.compact
+    if total_pages <= MAX_CURSOR_COUNT
+      BasicPageCursors.as_hash(total_pages, current_page, per_page)
+    else
+      {
+        around: around_cursors,
+        first: first_cursor,
+        last: last_cursor,
+        previous: previous_cursor
+      }.compact
+    end
   end
 
   def total_pages

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -25,9 +25,8 @@ class PageCursorResolver
 
   def total_pages
     return 0 if object_items.size.zero?
-    return 1 if nodes_per_page.nil?
 
-    (object_items.size.to_f / nodes_per_page).ceil
+    (object_items.size.to_f / per_page).ceil
   end
 
   def total_count
@@ -72,7 +71,7 @@ class PageCursorResolver
   end
 
   def page_cursor(page_number)
-    PageCursor.as_hash(current_page, page_number, nodes_per_page)
+    PageCursor.as_hash(current_page, page_number, per_page)
   end
 
   def around_page_numbers # rubocop:disable Metrics/AbcSize
@@ -91,10 +90,10 @@ class PageCursorResolver
     first_node = object.edge_nodes.first
     item_index = object_items.index(first_node) || 0
     nodes_before = item_index + 1
-    nodes_before / nodes_per_page + 1
+    nodes_before / per_page + 1
   end
 
-  def nodes_per_page
-    object.first || object.last
+  def per_page
+    object.first || object.last || 1
   end
 end

--- a/lib/page_cursor_resolver.rb
+++ b/lib/page_cursor_resolver.rb
@@ -2,6 +2,7 @@
 
 require 'page_cursor'
 require 'basic_page_cursors'
+require 'gapped_page_cursors'
 
 class PageCursorResolver
   MAX_CURSOR_COUNT = 5
@@ -13,18 +14,13 @@ class PageCursorResolver
     @context = context
   end
 
-  def page_cursors # rubocop:disable Metrics/MethodLength
+  def page_cursors
     return if total_pages <= 1
 
     if total_pages <= MAX_CURSOR_COUNT
       BasicPageCursors.as_hash(total_pages, current_page, per_page)
     else
-      {
-        around: around_cursors,
-        first: first_cursor,
-        last: last_cursor,
-        previous: previous_cursor
-      }.compact
+      GappedPageCursors.as_hash(total_pages, current_page, per_page)
     end
   end
 
@@ -44,51 +40,6 @@ class PageCursorResolver
     return object.nodes unless object.respond_to?(:items)
 
     object.items
-  end
-
-  def around_cursors
-    around_page_numbers.map { |page_num| page_cursor(page_num) }
-  end
-
-  def first_cursor
-    exceeds_max_cursor_count = total_pages > MAX_CURSOR_COUNT
-    include_first_cursor =
-      exceeds_max_cursor_count && !around_page_numbers.include?(1)
-    return unless include_first_cursor
-
-    page_cursor(1)
-  end
-
-  def last_cursor
-    exceeds_max_cursor_count = total_pages > MAX_CURSOR_COUNT
-    include_last_cursor =
-      exceeds_max_cursor_count && !around_page_numbers.include?(total_pages)
-    return unless include_last_cursor
-
-    page_cursor(total_pages)
-  end
-
-  def previous_cursor
-    include_previous_cursor = current_page > 1
-    return unless include_previous_cursor
-
-    page_cursor(current_page - 1)
-  end
-
-  def page_cursor(page_number)
-    PageCursor.as_hash(current_page, page_number, per_page)
-  end
-
-  def around_page_numbers # rubocop:disable Metrics/AbcSize
-    if total_pages <= MAX_CURSOR_COUNT
-      (1..total_pages).to_a
-    elsif current_page <= 3
-      (1..4).to_a
-    elsif current_page >= total_pages - 2
-      ((total_pages - 3)..total_pages).to_a
-    else
-      [current_page - 1, current_page, current_page + 1]
-    end
   end
 
   def current_page

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -5,7 +5,7 @@ require 'page_cursor_resolver'
 describe 'pagination' do
   context 'with 0 items' do
     it 'has no pages or cursors' do
-      object = double(:object, items: [])
+      object = double(:object, items: [], first: nil, last: nil, edge_nodes: [])
       results = PageCursorResolver.new(object, nil)
 
       expect(results.total_pages).to eq 0
@@ -18,7 +18,7 @@ describe 'pagination' do
     let(:item) { double :item }
 
     it 'has 1 page for 1 item and no cursors' do
-      object = double(:object, items: [item], first: nil, last: nil)
+      object = double(:object, items: [item], first: nil, last: nil, edge_nodes: [])
       results = PageCursorResolver.new(object, nil)
 
       expect(results.total_pages).to eq 1

--- a/spec/pagination_with_nodes_spec.rb
+++ b/spec/pagination_with_nodes_spec.rb
@@ -5,7 +5,7 @@ require 'page_cursor_resolver'
 describe 'pagination' do
   context 'with 0 items' do
     it 'has no pages or cursors' do
-      object = double(:object, nodes: [])
+      object = double(:object, nodes: [], first: nil, last: nil, edge_nodes: [])
       results = PageCursorResolver.new(object, nil)
 
       expect(results.total_pages).to eq 0
@@ -18,7 +18,7 @@ describe 'pagination' do
     let(:item) { double :item }
 
     it 'has 1 page for 1 item and no cursors' do
-      object = double(:object, nodes: [item], first: nil, last: nil)
+      object = double(:object, nodes: [item], first: nil, last: nil, edge_nodes: [])
       results = PageCursorResolver.new(object, nil)
 
       expect(results.total_pages).to eq 1


### PR DESCRIPTION
This PR takes the step of elevating our various types of pagination into proper classes that can be picked from. Let's look at the three types of pagination:

### No Pagination

<img width="1188" alt="Screen Shot 2020-11-13 at 4 53 13 PM" src="https://user-images.githubusercontent.com/79799/99128685-12477e80-25d1-11eb-95c1-1a10e6658d60.png">


This happens when we have fewer than 2 pages of results.

### Basic Pagination

<img width="1188" alt="Screen Shot 2020-11-13 at 4 53 30 PM" src="https://user-images.githubusercontent.com/79799/99128692-15db0580-25d1-11eb-8788-91000b8336fc.png">


This happens when we have 2-5 pages of results.

### Gapped Pagination

<img width="1188" alt="Screen Shot 2020-11-13 at 4 54 05 PM" src="https://user-images.githubusercontent.com/79799/99128694-196e8c80-25d1-11eb-87b6-9f8d598c7757.png">


This happens when we have 6 or more pages of results.

## Lining up classes and types of pagination

So the real punchline of this PR is embracing these various modes by defining a single method that tells us these rules:

```rb
  def cursor_klass
    if total_pages < MIN_CURSOR_COUNT
      NullPageCursors
    elsif total_pages <= MAX_CURSOR_COUNT
      BasicPageCursors
    else
      GappedPageCursors
    end
  end
```

These are the pagination rules - if you don't have enough pages we don't run pagination. If you have a small number of pages we run the basic version and if you have a lot then we run our fancy gapped one.